### PR TITLE
Make the install directory configurable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,3 +93,36 @@ jobs:
         echo
       env:
         COMBINATION: 1
+
+  install-dir-test:
+    runs-on: windows-latest
+    name: 'Check install directory behaviour'
+
+    strategy:
+      matrix:
+        include:
+          - install-dir: C:\tools\cygwin
+          - install-dir: D:\cygwin64
+
+    steps:
+    - run: git config --global core.autocrlf input
+
+    - uses: actions/checkout@v2
+
+    - name: Install Cygwin
+      uses: ./
+      with:
+        install-dir: "${{ matrix.install-dir }}"
+
+    - name: Check working directory
+      run: |
+        if [[ "$(cygpath -aw /)" == '${{ matrix.install-dir }}' ]]; then
+          echo "Installed in $(cygpath -aw /)"
+        else
+          exit 1
+        fi
+      # Only specify the shell by name; GitHub actions should find the correct
+      # executable thanks to the action setting the path appropriately.
+      shell: bash
+      env:
+        SHELLOPTS: igncr

--- a/README.md
+++ b/README.md
@@ -18,10 +18,11 @@ Please fix my terrible cargo-cult PowerShell.
 Parameters
 ----------
 
-| Input       | Default | Description
-| ----------- | ------- | -----------
-| platform    | x86_64  | Install the x86 or x86\_64 version of Cygwin.
-| packages    | *none*  | List of additional packages to install.
+| Input       | Default   | Description
+| ----------- | --------- | -----------
+| platform    | x86_64    | Install the x86 or x86\_64 version of Cygwin.
+| packages    | *none*    | List of additional packages to install.
+| install-dir | C:\cygwin | Installation directory
 
 Line endings
 ------------

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,12 @@ inputs:
   packages:
     description: Packages to install
     required: false
+  install-dir:
+    # by default, install to C:\cygwin rather than the platform dependent
+    # default to make everything simpler
+    description: Installation directory
+    required: false
+    default: C:\cygwin
 
 runs:
   using: "composite"
@@ -35,9 +41,7 @@ runs:
          '-qgnO',
          '-s', 'http://mirrors.kernel.org/sourceware/cygwin/',
          '-l', 'C:\cygwin-packages',
-         # always install to C:\cygwin rather than the platform dependent
-         # default to make everything simpler
-         '-R', 'C:\cygwin'
+         '-R', '${{ inputs.install-dir }}'
         )
 
         if ($pkg_list.Count -gt 0) {
@@ -51,9 +55,9 @@ runs:
       shell: powershell
 
     - run: |
-        echo "C:\cygwin\bin" >> $env:GITHUB_PATH
+        echo "${{ inputs.install-dir }}\bin" >> $env:GITHUB_PATH
         # run login shell to copy skeleton profile files
-        C:\cygwin\bin\bash.exe --login
+        ${{ inputs.install-dir }}\bin\bash.exe --login
       shell: powershell
 
 branding:


### PR DESCRIPTION
Default to maintaining the current behaviour, but allow users of this
action to change the install directory.  This means it's possible, for
example, to use the default-everywhere-else behaviour of installing
64-bit Cygwin to C:\cygwin64, or to ease migration from other GitHub
Actions such as egor-tensin/setup-cygwin, which defaults to installing
in C:\tools\cygwin.