### PR TITLE
Add support for the Cygwin Time Machine

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -174,6 +174,10 @@ jobs:
         site: http://ctm.crouchingtigerhiddenfruitbat.org/pub/cygwin/circa/64bit/2021/01/22/181752
       continue-on-error: true
 
+    # The install step should have failed due to the duff signature.  Check
+    # that by trying to run Bash: if Cygwin were installed correctly, we'd run
+    # Cygwin Bash; if it isn't, we'll run one of the non-Cygwin Bash
+    # executables provided by the GitHub runner.
     - name: Check Cygwin isn't installed
       run: |
         if [[ "${OSTYPE}" = "cygwin" ]]; then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -132,3 +132,54 @@ jobs:
       shell: bash
       env:
         SHELLOPTS: igncr
+
+  time-machine:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+
+    name: 'Test time machine signature'
+
+    steps:
+    - run: git config --global core.autocrlf input
+
+    - uses: actions/checkout@v2
+
+    - name: Install Cygwin
+      uses: ./
+      with:
+        site: http://ctm.crouchingtigerhiddenfruitbat.org/pub/cygwin/circa/64bit/2021/01/22/181752
+        check-sig: false
+
+    - name: Check cygwin version
+      run: |
+        cygcheck -cd cygwin | grep -qF 3.1.7-1
+      shell: C:\cygwin\bin\bash.exe --noprofile --norc -o igncr -eo pipefail '{0}'
+
+  bad-sig:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+
+    name: 'Test failure of time machine signature'
+
+    steps:
+    - run: git config --global core.autocrlf input
+
+    - uses: actions/checkout@v2
+
+    - name: Fail to install Cygwin
+      uses: ./
+      with:
+        site: http://ctm.crouchingtigerhiddenfruitbat.org/pub/cygwin/circa/64bit/2021/01/22/181752
+      continue-on-error: true
+
+    - name: Check Cygwin isn't installed
+      run: |
+        if [[ "${OSTYPE}" = "cygwin" ]]; then
+          echo "Unexpectedly running Cygwin"
+          exit 1
+        fi
+      shell: bash
+      env:
+        SHELLOPTS: igncr

--- a/README.md
+++ b/README.md
@@ -18,11 +18,13 @@ Please fix my terrible cargo-cult PowerShell.
 Parameters
 ----------
 
-| Input       | Default   | Description
-| ----------- | --------- | -----------
-| platform    | x86_64    | Install the x86 or x86\_64 version of Cygwin.
-| packages    | *none*    | List of additional packages to install.
-| install-dir | C:\cygwin | Installation directory
+| Input       | Default                                      | Description
+| ----------- | -------------------------------------------- | -----------
+| platform    | x86_64                                       | Install the x86 or x86\_64 version of Cygwin.
+| packages    | *none*                                       | List of additional packages to install.
+| install-dir | C:\cygwin                                    | Installation directory
+| site        | http://mirrors.kernel.org/sourceware/cygwin/ | Mirror site to install from
+| check-sig   | true                                         | Whether to check the setup.ini signature
 
 Line endings
 ------------
@@ -76,6 +78,15 @@ created, so some executables (e.g. `python`) are created as Cygwin-style
 symlinks. Since CMD and PowerShell don't understand those symlinks, you cannot
 run those executables directly in a `run:` in your workflow. Execute them via
 `bash` or `env` instead.
+
+Mirrors and signatures
+----------------------
+
+You probably don't need to change the setting for `site`, and you shouldn't
+change `check-sig` unless you're very confident it's appropriate and necessary.
+These options are very unlikely to be useful except in some very isolated
+circumstances, such as using the [Cygwin Time
+Machine](http://www.crouchingtigerhiddenfruitbat.org/Cygwin/timemachine.html).
 
 [1] The
 [Workflow documentation](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference)

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,14 @@ inputs:
     description: Installation directory
     required: false
     default: C:\cygwin
+  check-sig:
+    description: Should the setup.ini file signature be checked?
+    required: false
+    default: true
+  site:
+    description: Download site URL
+    required: false
+    default: http://mirrors.kernel.org/sourceware/cygwin/
 
 runs:
   using: "composite"
@@ -39,7 +47,7 @@ runs:
 
         $args = @(
          '-qgnO',
-         '-s', 'http://mirrors.kernel.org/sourceware/cygwin/',
+         '-s', '${{ inputs.site }}',
          '-l', 'C:\cygwin-packages',
          '-R', '${{ inputs.install-dir }}'
         )
@@ -47,6 +55,10 @@ runs:
         if ($pkg_list.Count -gt 0) {
           $args += '-P'
           $args += $pkg_list -Join(',')
+        }
+
+        if ('${{ inputs.check-sig }}' -eq $false) {
+          $args += '-X'
         }
 
         # because setup is a Windows GUI app, make it part of a pipeline to make


### PR DESCRIPTION
Using the Cygwin Time Machine requires (a) being able to specify the
mirror that's used for installing Cygwin, and (b) being able to disable
the signature checks the installer performs.  Add options that allow
that, tests to check it works as expected, and documentation for the new
options.