### PR TITLE
Add package caching

### DIFF
--- a/.github/workflows/cache-perf.yml
+++ b/.github/workflows/cache-perf.yml
@@ -1,0 +1,48 @@
+name: Cache performance testing
+
+# Only run manually: the purpose of this test is to check how much (if at all)
+# using the caches helps, and that's not something that needs doing often, and
+# it is something that's time consuming.
+on: workflow_dispatch
+
+# Avoid running at the same time as other actions that interfere with caches,
+# to avoid pollution.
+concurrency: caches
+
+jobs:
+  clear-caches:
+    uses: ./.github/workflows/clear-caches.yml
+    permissions:
+      actions: write
+
+  # There should now be no cache, so we can test how long it takes to do an
+  # install without a cache while building the cache for the later action.
+  install-without-cache:
+    runs-on: windows-latest
+    needs: clear-caches
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install a large set of Cygwin packages
+        uses: ./
+        with:
+          packages: >
+            biber doxygen evolution kde-dev-utils
+            mkvtoolnix-debuginfo nghttp x11vnc
+          package-cache: saveonly
+
+  install-with-cache:
+    runs-on: windows-latest
+    needs: install-without-cache
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install a large set of Cygwin packages
+        uses: ./
+        with:
+          packages: >
+            biber doxygen evolution kde-dev-utils
+            mkvtoolnix-debuginfo nghttp x11vnc
+          package-cache: enabled

--- a/.github/workflows/cache-test.yml
+++ b/.github/workflows/cache-test.yml
@@ -1,0 +1,193 @@
+name: Caching tests
+
+on: [push, pull_request]
+
+# Ensure there's only a single version of this running in any repo, so one set
+# of tests won't create or destroy caches that interfere with another run.
+concurrency: caches
+
+jobs:
+  clear-caches:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      # This will only delete up to 100 caches.  That should be far more than
+      # is ever needed.
+      - name: Delete cache entries
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const response = await github.rest.actions.getActionsCacheList({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              per_page: 100,
+              key: 'cygwin-install-action-packages-'
+            });
+            for (const cache of response.data.actions_caches) {
+              await github.rest.actions.deleteActionsCacheById({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                cache_id: cache.id
+              });
+            }
+
+  test-caching:
+    runs-on: windows-latest
+
+    needs: clear-caches
+
+    # Ordering is important here to ensure the correct things are in the
+    # correct caches at the correct times.
+    #
+    # This also relies on having six Cygwin packages that don't have any
+    # cross-dependencies (and ideally are small and have few dependencies of
+    # their own), so we can distinguish what's cached at what step.
+    #
+    # We test for the correct behaviour in the following circumstances:
+    #
+    # option      | saves   | restores
+    # ------------+---------+----------
+    # disabled    | no (1)  | no (5)
+    # enabled     | yes (2) | yes (6)
+    # saveonly    | yes (3) | no (7)
+    # restoreonly | no (4)  | yes (8)
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install Cygwin + bash_completion, no caching
+        uses: ./
+        with:
+          packages: bash-completion
+          package-cache: disabled
+
+      - name: Delete the Cygwin installation and downloaded packages
+        run: |
+          Remove-Item -Force -Recurse C:\cygwin
+          Remove-Item -Force -Recurse C:\cygwin-packages
+          Remove-Item -Force -Recurse C:\cygwin-packages-checksum.*
+
+      - name: Install Cygwin + brotli, with caching
+        uses: ./
+        with:
+          packages: brotli
+          package-cache: enabled
+
+      # This assumes 6 and tests 1
+      - name: Ensure bash-completion not downloaded
+        shell: C:\cygwin\bin\bash.exe --noprofile --norc -e -o pipefail -o igncr {0}
+        run: |
+          for file in /cygdrive/c/cygwin-packages/*/*/*/*/bash-completion-*.tar.*; do
+            [[ -f "$file" ]] && exit 1
+          done
+          exit 0
+
+      - name: Delete the Cygwin installation and downloaded packages
+        run: |
+          Remove-Item -Force -Recurse C:\cygwin
+          Remove-Item -Force -Recurse C:\cygwin-packages
+          Remove-Item -Force -Recurse C:\cygwin-packages-checksum.*
+
+      - name: Install Cygwin + libyajl2, with caching
+        uses: ./
+        with:
+          packages: libyajl2
+          package-cache: enabled
+
+      # This tests 2 and 6
+      - name: Ensure brotli downloaded
+        shell: C:\cygwin\bin\bash.exe --noprofile --norc -e -o pipefail -o igncr {0}
+        run: |
+          for file in /cygdrive/c/cygwin-packages/*/*/*/*/brotli-*.tar.*; do
+            [[ -f "$file" ]] && exit 0
+          done
+          exit 1
+
+      - name: Delete the Cygwin installation and downloaded packages
+        run: |
+          Remove-Item -Force -Recurse C:\cygwin
+          Remove-Item -Force -Recurse C:\cygwin-packages
+          Remove-Item -Force -Recurse C:\cygwin-packages-checksum.*
+
+      - name: Install Cygwin + mksh, saveonly
+        uses: ./
+        with:
+          packages: mksh
+          package-cache: saveonly
+
+      # This assumes 2 and tests 7
+      - name: Ensure libyajl2 not downloaded
+        shell: C:\cygwin\bin\bash.exe --noprofile --norc -e -o pipefail -o igncr {0}
+        run: |
+          for file in /cygdrive/c/cygwin-packages/*/*/*/*/libyajl2-*.tar.*; do
+            [[ -f "$file" ]] && exit 1
+          done
+          exit 0
+
+      - name: Delete the Cygwin installation and downloaded packages
+        run: |
+          Remove-Item -Force -Recurse C:\cygwin
+          Remove-Item -Force -Recurse C:\cygwin-packages
+          Remove-Item -Force -Recurse C:\cygwin-packages-checksum.*
+
+      - name: Install Cygwin + libgif7, restoreonly
+        uses: ./
+        with:
+          packages: libgif7
+          package-cache: restoreonly
+
+      # This tests 3 and 8
+      - name: Ensure mksh downloaded
+        shell: C:\cygwin\bin\bash.exe --noprofile --norc -e -o pipefail -o igncr {0}
+        run: |
+          for file in /cygdrive/c/cygwin-packages/*/*/*/*/mksh-*.tar.*; do
+            [[ -f "$file" ]] && exit 1
+          done
+          exit 0
+
+      - name: Delete the Cygwin installation and downloaded packages
+        run: |
+          Remove-Item -Force -Recurse C:\cygwin
+          Remove-Item -Force -Recurse C:\cygwin-packages
+          Remove-Item -Force -Recurse C:\cygwin-packages-checksum.*
+
+      - name: Install Cygwin, restoreonly
+        uses: ./
+        with:
+          package-cache: restoreonly
+
+      # This assumes 8 and tests 4
+      - name: Ensure libgif7 not downloaded
+        shell: C:\cygwin\bin\bash.exe --noprofile --norc -e -o pipefail -o igncr {0}
+        run: |
+          for file in /cygdrive/c/cygwin-packages/*/*/*/*/libgif7-*.tar.*; do
+            [[ -f "$file" ]] && exit 1
+          done
+          exit 0
+
+      - name: Delete the Cygwin installation and downloaded packages
+        run: |
+          Remove-Item -Force -Recurse C:\cygwin
+          Remove-Item -Force -Recurse C:\cygwin-packages
+          Remove-Item -Force -Recurse C:\cygwin-packages-checksum.*
+
+      - name: Install Cygwin, caching disabled
+        uses: ./
+        with:
+          package-cache: disabled
+
+      # This assumes 3 and tests 5
+      - name: Ensure mksh not downloaded
+        shell: C:\cygwin\bin\bash.exe --noprofile --norc -e -o pipefail -o igncr {0}
+        run: |
+          for file in /cygdrive/c/cygwin-packages/*/*/*/*/mksh-*.tar.*; do
+            [[ -f "$file" ]] && exit 1
+          done
+          exit 0
+
+      - name: Delete the Cygwin installation and downloaded packages
+        run: |
+          Remove-Item -Force -Recurse C:\cygwin
+          Remove-Item -Force -Recurse C:\cygwin-packages
+          Remove-Item -Force -Recurse C:\cygwin-packages-checksum.*

--- a/.github/workflows/cache-test.yml
+++ b/.github/workflows/cache-test.yml
@@ -8,29 +8,9 @@ concurrency: caches
 
 jobs:
   clear-caches:
-    runs-on: ubuntu-latest
+    uses: ./.github/workflows/clear-caches.yml
     permissions:
       actions: write
-    steps:
-      # This will only delete up to 100 caches.  That should be far more than
-      # is ever needed.
-      - name: Delete cache entries
-        uses: actions/github-script@v6
-        with:
-          script: |
-            const response = await github.rest.actions.getActionsCacheList({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              per_page: 100,
-              key: 'cygwin-install-action-packages-'
-            });
-            for (const cache of response.data.actions_caches) {
-              await github.rest.actions.deleteActionsCacheById({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                cache_id: cache.id
-              });
-            }
 
   test-caching:
     runs-on: windows-latest

--- a/.github/workflows/clear-caches.yml
+++ b/.github/workflows/clear-caches.yml
@@ -1,0 +1,29 @@
+name: Clear Cygwin package caches
+
+on: workflow_call
+
+jobs:
+  clear-caches:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      # This will only delete up to 100 caches.  That should be far more than
+      # is ever needed.
+      - name: Delete cache entries
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const response = await github.rest.actions.getActionsCacheList({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              per_page: 100,
+              key: 'cygwin-install-action-packages-'
+            });
+            for (const cache of response.data.actions_caches) {
+              await github.rest.actions.deleteActionsCacheById({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                cache_id: cache.id
+              });
+            }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -228,34 +228,3 @@ jobs:
       shell: bash
       env:
         SHELLOPTS: igncr
-
-  caching:
-    runs-on: windows-latest
-
-    name: 'Test use of the cache'
-
-    steps:
-      - run: git config --global core.autocrlf input
-      - uses: actions/checkout@v2
-      - name: Install Cygwin and bash-completion
-        uses: ./
-        with:
-          packages: bash-completion
-          package-cache: enabled
-          add-to-path: false
-      - name: Delete Cygwin installation and cache
-        run: |
-          Remove-Item -Force -Recurse C:\cygwin
-          Remove-Item -Force -Recurse C:\cygwin-packages
-      - name: Reinstall Cygwin only
-        uses: ./
-        with:
-          package-cache-key: enabled
-          add-to-path: false
-      - name: Find bash-completion in the package cache
-        shell: C:\cygwin\bin\bash.exe --noprofile --norc -e -o pipefail -o igncr {0}
-        run: |
-          for file in /cygdrive/c/cygwin-packages/*/*/*/bash-completion/bash-completion-*.tar.*; do
-            [[ -f "$file" ]] && exit 0  # File actually exists
-          done
-          exit 1  # No such downloaded file

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -228,3 +228,34 @@ jobs:
       shell: bash
       env:
         SHELLOPTS: igncr
+
+  caching:
+    runs-on: windows-latest
+
+    name: 'Test use of the cache'
+
+    steps:
+      - run: git config --global core.autocrlf input
+      - uses: actions/checkout@v2
+      - name: Install Cygwin and bash-completion
+        uses: ./
+        with:
+          packages: bash-completion
+          package-cache-key: testing-cache
+          add-to-path: false
+      - name: Delete Cygwin installation and cache
+        run: |
+          Remove-Item -Force -Recurse C:\cygwin
+          Remove-Item -Force -Recurse C:\cygwin-packages
+      - name: Reinstall Cygwin only
+        uses: ./
+        with:
+          package-cache-key: testing-cache
+          add-to-path: false
+      - name: Find bash-completion in the package cache
+        shell: C:\cygwin\bin\bash.exe --noprofile --norc -e -o pipefail -o igncr {0}
+        run: |
+          for file in /cygdrive/c/cygwin-packages/*/*/*/bash-completion/bash-completion-*.tar.*; do
+            [[ -f "$file" ]] && exit 0  # File actually exists
+          done
+          exit 1  # No such downloaded file

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -241,7 +241,7 @@ jobs:
         uses: ./
         with:
           packages: bash-completion
-          package-cache-key: testing-cache
+          package-cache: enabled
           add-to-path: false
       - name: Delete Cygwin installation and cache
         run: |
@@ -250,7 +250,7 @@ jobs:
       - name: Reinstall Cygwin only
         uses: ./
         with:
-          package-cache-key: testing-cache
+          package-cache-key: enabled
           add-to-path: false
       - name: Find bash-completion in the package cache
         shell: C:\cygwin\bin\bash.exe --noprofile --norc -e -o pipefail -o igncr {0}

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Parameters
 | site        | http://mirrors.kernel.org/sourceware/cygwin/ | Mirror site to install from
 | check-sig   | true                                         | Whether to check the setup.ini signature
 | add-to-path | true                                         | Whether to add Cygwin's `/bin` directory to the system `PATH`
+| package-cache-key | ''                                     | The key to use for caching downloaded packages.
 
 Line endings
 ------------
@@ -84,6 +85,22 @@ those executables directly in a `run:` in your workflow. Execute them via
 
 Alternatively, putting e.g. `CYGWIN=winsymlinks:native` into the workflow's
 environment works, since setup now honours that.
+
+Caching
+-------
+
+If you're likely to do regular builds, you might want to store the packages
+locally rather than needing to download them from the Cygwin mirrors on every
+build.  Set `package-cache-key` to some string (e.g. `cygwin-package-cache`),
+and the action will use [GitHub's dependency caching][0] to store downloaded
+package files between runs.
+
+[0]: https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows
+
+This has the effect of speeding up the run of the installation itself, at the
+expense of taking slightly longer before and after the installation to check
+and potentially update the cache.  The installer will still check for updated
+packages, and will download new packages if the cached ones are out of date
 
 Mirrors and signatures
 ----------------------

--- a/README.md
+++ b/README.md
@@ -18,15 +18,15 @@ Please fix my terrible cargo-cult PowerShell.
 Parameters
 ----------
 
-| Input       | Default                                      | Description
-| ----------- | -------------------------------------------- | -----------
-| platform    | x86_64                                       | Install the x86 or x86\_64 version of Cygwin.
-| packages    | *none*                                       | List of additional packages to install.
-| install-dir | C:\cygwin                                    | Installation directory
-| site        | http://mirrors.kernel.org/sourceware/cygwin/ | Mirror site to install from
-| check-sig   | true                                         | Whether to check the setup.ini signature
-| add-to-path | true                                         | Whether to add Cygwin's `/bin` directory to the system `PATH`
-| package-cache-key | ''                                     | The key to use for caching downloaded packages.
+| Input         | Default                                      | Description
+| ------------- | -------------------------------------------- | -----------
+| platform      | x86_64                                       | Install the x86 or x86\_64 version of Cygwin.
+| packages      | *none*                                       | List of additional packages to install.
+| install-dir   | C:\cygwin                                    | Installation directory
+| site          | http://mirrors.kernel.org/sourceware/cygwin/ | Mirror site to install from
+| check-sig     | true                                         | Whether to check the setup.ini signature
+| add-to-path   | true                                         | Whether to add Cygwin's `/bin` directory to the system `PATH`
+| package-cache | disabled                                     | Whether to cache the package downloads
 
 Line endings
 ------------
@@ -91,9 +91,8 @@ Caching
 
 If you're likely to do regular builds, you might want to store the packages
 locally rather than needing to download them from the Cygwin mirrors on every
-build.  Set `package-cache-key` to some string (e.g. `cygwin-package-cache`),
-and the action will use [GitHub's dependency caching][0] to store downloaded
-package files between runs.
+build.  Set `package-cache` to `enabled` and the action will use [GitHub's
+dependency caching][0] to store downloaded package files between runs.
 
 [0]: https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows
 
@@ -101,6 +100,25 @@ This has the effect of speeding up the run of the installation itself, at the
 expense of taking slightly longer before and after the installation to check
 and potentially update the cache.  The installer will still check for updated
 packages, and will download new packages if the cached ones are out of date
+
+In certain circumstances you might want to ignore any existing caches but still
+store a new one, or restore a cache but not write one.  Do this by setting
+`package-cache` to `saveonly` or `restoreonly` as appropriate.  This is
+particularly useful when calling the action multiple times in the same run,
+where you probably want to restore the cache the first time the action is
+called, then save it the last time it is called.
+
+You should make sure to clear these caches every so often.  This action, like
+the underlying Cygwin installer, doesn't remove old package files from its
+download directory, so if you don't clear the caches occasionally (and you run
+builds often enough that GitHub doesn't do it for you automatically) you'll
+find the caches keep getting larger as they gain more and more outdated and
+unused packages.  Either [delete them manually][1], [use a separate action or
+API call][2], or do occasional runs with `saveonly` to create a fresher small
+cache.
+
+[1]: https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#deleting-cache-entries
+[2]: https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#deleting-cache-entries
 
 Mirrors and signatures
 ----------------------

--- a/action.yml
+++ b/action.yml
@@ -26,24 +26,26 @@ inputs:
     description: Should Cygwin's bin directory be added to the system PATH?
     required: false
     default: true
-  package-cache-key:
-    description: Key prefix to use for package caches
+  package-cache:
+    description: Cache package downloads for speed
     required: false
-    default: ''
+    default: disabled
 
 runs:
   using: "composite"
   steps:
     - uses: actions/cache/restore@v3
-      if: inputs.package-cache-key != ''
+      if: inputs.package-cache-behaviour == 'enabled' || inputs.package-cache-behaviour == 'restoreonly'
       with:
-        key: ${{ inputs.package-cache-key }}-${{ github.run_id }}-${{ github.run_attempt }}
+        key: cygwin-install-action-packages-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}-${{ github.action }}
         path: C:\cygwin-packages
         restore-keys:
-          ${{ inputs.package-cache-key }}-${{ github.run_id }}-
-          ${{ inputs.package-cache-key }}-
+          cygwin-install-action-packages-${{ github.run_id }}-${{ github.job }}-${{ github.run_attempt }}-
+          cygwin-install-action-packages-${{ github.run_id }}-${{ github.job }}-
+          cygwin-install-action-packages-${{ github.run_id }}-
+          cygwin-install-action-packages-
 
-    - if: inputs.package-cache-key != ''
+    - if: inputs.package-cache-behaviour == 'enabled' || inputs.package-cache-behaviour == 'restoreonly'
       working-directory: C:\
       shell: bash
       run: |
@@ -105,7 +107,7 @@ runs:
         & C:\setup.exe $args | Out-Default
       shell: powershell
 
-    - if: inputs.package-cache-key != ''
+    - if: inputs.package-cache-behaviour == 'enabled' || inputs.package-cache-behaviour == 'saveonly'
       id: refresh-cache
       working-directory: C:\
       shell: bash
@@ -122,7 +124,7 @@ runs:
     - if: steps.refresh-cache.outputs.update_package_cache != ''
       uses: actions/cache/save@v3
       with:
-        key: ${{ inputs.package-cache-key }}-${{ github.run_id }}-${{ github.run_attempt }}
+        key: cygwin-install-action-packages-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}-${{ github.action }}
         path: C:\cygwin-packages
 
     - if: ${{ inputs.add-to-path  == 'true' }}

--- a/action.yml
+++ b/action.yml
@@ -26,10 +26,33 @@ inputs:
     description: Should Cygwin's bin directory be added to the system PATH?
     required: false
     default: true
+  package-cache-key:
+    description: Key prefix to use for package caches
+    required: false
+    default: ''
 
 runs:
   using: "composite"
   steps:
+    - uses: actions/cache/restore@v3
+      if: inputs.package-cache-key != ''
+      with:
+        key: ${{ inputs.package-cache-key }}-${{ github.run_id }}-${{ github.run_attempt }}
+        path: C:\cygwin-packages
+        restore-keys:
+          ${{ inputs.package-cache-key }}-${{ github.run_id }}-
+          ${{ inputs.package-cache-key }}-
+
+    - if: inputs.package-cache-key != ''
+      working-directory: C:\
+      shell: bash
+      run: |
+        if [[ -d cygwin-packages ]]; then
+          find cygwin-packages -type f ! -name setup.ini -print0 |
+            sort -z |
+            xargs -0 b2sum >cygwin-packages-checksum.old
+        fi
+
     - run: |
         $platform = '${{ inputs.platform }}'
         $platform = $platform -replace '^(x64|amd64)$', 'x86_64'
@@ -81,6 +104,26 @@ runs:
         # PowerShell wait for it to exit
         & C:\setup.exe $args | Out-Default
       shell: powershell
+
+    - if: inputs.package-cache-key != ''
+      id: refresh-cache
+      working-directory: C:\
+      shell: bash
+      run: |
+        if [[ -d cygwin-packages ]]; then
+          find cygwin-packages -type f ! -name setup.ini -print0 |
+            sort -z |
+            xargs -0 b2sum >cygwin-packages-checksum.new
+          if ! diff cygwin-packages-checksum.old cygwin-packages-checksum.new; then
+            printf 'update_package_cache=YesPlease\n' >>"$GITHUB_OUTPUT"
+          fi
+        fi
+
+    - if: steps.refresh-cache.outputs.update_package_cache != ''
+      uses: actions/cache/save@v3
+      with:
+        key: ${{ inputs.package-cache-key }}-${{ github.run_id }}-${{ github.run_attempt }}
+        path: C:\cygwin-packages
 
     - if: ${{ inputs.add-to-path  == 'true' }}
       run: echo "${{ inputs.install-dir }}\bin" >> $env:GITHUB_PATH


### PR DESCRIPTION
To speed up Cygwin installations, allow users to store the downloaded packages using GitHub's caching, rather than needing the packages to be downloaded from the Cygwin mirrors on every run.

This speeds up the installation when there's a good cache hit, at the expense of adding some additional complexity, and using the limited cache space (although with 10GB assigned to every repository on GitHub, I can't imagine most folk are getting close to the limit!).

To avoid unnecessary cache churn, the new steps check if the cache has actually meaningfully changed before storing a new cache.  This uses b2sum for speed, since we're just checking for unexpected changes in the cache, and we don't need cryptographic security.

I was originally working on this for my own builds, e.g. at <https://github.com/me-and/Cygwin-inih/blob/fb7534276feeb2a5217df5013c679a370ee6013e/.github/workflows/ci.yml>, but it occurred to me that this might be more useful here than in my own repos.