### PR TITLE
Add warning about using SHELLOPTS to set igncr

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ newlines.
 
 Alternatively, you can also use:
 
-- `igncr` in the `SHELLOPTS` environment variable
 - invoke `bash` with `-o igncr`
+- `igncr` in the `SHELLOPTS` environment variable (**Warning:** by default, `SHELLOPTS` is a shell variable and moving it to the environment causes all shell options to propagate to child shells)
 
 PATH
 ----


### PR DESCRIPTION
By default, `SHELLOPTS` is a shell variable and moving it to the environment causes all shell options to propagate to child shells. This may break scripts in a confusing way, so it is not a good idea to recommend it without at least providing a warning.

Perhaps cygwin-install-action could provide an option to set up `BASH_ENV` with a file containing `set -o igncr`. [setup-ocaml does this](https://github.com/ocaml/setup-ocaml/pull/921) when configuring cygwin.

See:
- https://github.com/ocaml/setup-ocaml/issues/920
- https://lists.gnu.org/archive/html/bug-bash/2025-01/msg00012.html