### PR TITLE
add `packages-dir` custom option

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Parameters
 | pubkeys             | *none*                                       | Absolute paths of extra public key files (RFC4880 format), separated by whitespace
 | check-sig           | true                                         | Whether to check the setup.ini signature
 | add-to-path         | true                                         | Whether to add Cygwin's `/bin` directory to the system `PATH`
+| packages-dir        | C:\cygwin-packages                           | Directory to store downloaded packages
 | allow-test-packages | false                                        | Consider package versions marked test for installation
 | check-hash          | true                                         | Whether to check the hash of the downloaded Cygwin installer.
 

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,10 @@ inputs:
     description: Should Cygwin's bin directory be added to the system PATH?
     required: false
     default: 'true'
+  packages-dir:
+    description: Packages directory
+    required: false
+    default: C:\cygwin-packages
   allow-test-packages:
     description: Consider package versions marked test
     required: false
@@ -85,7 +89,7 @@ runs:
 
         $args = @(
          '-qnO',
-         '-l', 'C:\cygwin-packages',
+         '-l', '${{ inputs.packages-dir }}',
          '-R', '${{ inputs.install-dir }}'
         )
 


### PR DESCRIPTION
To allow making installation a little bit faster by using the faster
`D:` drive on GitHub Windows runner machines.

Fixes #7
