### PR TITLE
retry network operations 3 times

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -52,13 +52,13 @@ runs:
           exit 1
         }
         $setupFileName = "setup-$platform.exe"
-        Invoke-WebRequest "https://cygwin.com/$setupFileName" -OutFile C:\setup.exe
+        Invoke-WebRequest "https://cygwin.com/$setupFileName" -OutFile C:\setup.exe -MaximumRetryCount 3
         if ((Get-Item -LiteralPath 'C:\setup.exe').Length -eq 0) {
           throw "The downloaded setup has a zero length!"
         }
 
         if ('${{ inputs.check-hash }}' -eq 'true') {
-          $expectedHashLines = $(Invoke-WebRequest -Uri https://cygwin.com/sha512.sum).ToString() -split "`n"
+          $expectedHashLines = $(Invoke-WebRequest -Uri https://cygwin.com/sha512.sum -MaximumRetryCount 3).ToString() -split "`n"
           $expectedHash = ''
           foreach ($expectedHashLine in $expectedHashLines) {
             if ($expectedHashLine.EndsWith(" $setupFileName")) {


### PR DESCRIPTION
To avoid transient network or server issues.

---

I'm not sure if the required PowerShell is present in CI runners. 5.1 doesn't support this option, 7.4 (LTS) does.
A CI run should clarify it.

Ref: https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/invoke-webrequest?view=powershell-7.4#-maximumretrycount
