### PR TITLE
Add a wrapper script to the PATH for use as shell

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -235,7 +235,11 @@ runs:
         if ('${{ inputs.login-shell }}' -eq $true) {
           $loginshell = "l"
         }
-        Set-Content -Path (Join-Path $wrapperDir "cygwin.cmd") -Value "@echo off`r`nset CHERE_INVOKING=1`r`n$installDir\\bin\\bash.exe --noprofile --norc -o igncr -${loginshell}eo pipefail %*"
+        Set-Content -Path (Join-Path $wrapperDir "cygwin.cmd") -Value @"
+        @echo off`r
+        set CHERE_INVOKING=1`r
+        $installDir\\bin\\bash.exe --noprofile --norc -o igncr -${loginshell}eo pipefail %*
+        "@
         echo "$wrapperDir" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
         # run login shell to copy skeleton profile files

--- a/action.yml
+++ b/action.yml
@@ -238,7 +238,7 @@ runs:
         Set-Content -Path (Join-Path $wrapperDir "cygwin.cmd") -Value @"
         @echo off`r
         set CHERE_INVOKING=1`r
-        $installDir\\bin\\bash.exe --noprofile --norc -o igncr -${loginshell}eo pipefail %*
+        $installDir\\bin\\bash.exe -o igncr -${loginshell}eo pipefail %*
         "@
         echo "$wrapperDir" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 

--- a/action.yml
+++ b/action.yml
@@ -45,6 +45,10 @@ inputs:
     description: Volume on which to store setup and packages, and install Cygwin
     required: false
     default: ''
+  login-shell:
+    description: Use a login shell when using wrapper script
+    required: false
+    default: 'true'
 
 outputs:
   setup:
@@ -223,6 +227,16 @@ runs:
         if ('${{ inputs.add-to-path }}' -eq 'true') {
           echo "$installDir\bin" >> $env:GITHUB_PATH
         }
+
+        # add a wrapper script to put on path, since a run step's shell doesn't accept output variable substitutions
+        $wrapperDir = Join-Path $env:RUNNER_TEMP ([IO.Path]::GetRandomFileName())
+        New-Item -Path $wrapperDir -ItemType Directory -Force | Out-Null
+        $loginshell = ""
+        if ('${{ inputs.login-shell }}' -eq $true) {
+          $loginshell = "l"
+        }
+        Set-Content -Path (Join-Path $wrapperDir "cygwin.cmd") -Value "@echo off`r`nset CHERE_INVOKING=1`r`n$installDir\\bin\\bash.exe --noprofile --norc -o igncr -${loginshell}eo pipefail %*"
+        echo "$wrapperDir" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
         # run login shell to copy skeleton profile files
         & "$installDir\bin\bash.exe" --login


### PR DESCRIPTION
Output variables don't work in the `shell` parameter of `run` steps (actions/runner#444), so create a wrapper script in a temp directory that's added to the path so that users can use `shell: cygwin '{0}'` without putting all of Cygwin's /bin on their PATH.

Fixes #29 