### PR TITLE
Move the install script to a dedicated file

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -61,177 +61,20 @@ runs:
   using: "composite"
   steps:
     - id: cygwin-install-action
+      env:
+        inputs_platform: "${{ inputs.platform }}"
+        inputs_packages: "${{ inputs.packages }}"
+        inputs_install_dir: "${{ inputs.install-dir }}"
+        inputs_check_sig: "${{ inputs.check-sig }}"
+        inputs_pubkeys: "${{ inputs.pubkeys }}"
+        inputs_site: "${{ inputs.site }}"
+        inputs_add_to_path: "${{ inputs.add-to-path }}"
+        inputs_allow_test_packages: "${{ inputs.allow-test-packages }}"
+        inputs_check_hash: "${{ inputs.check-hash }}"
+        inputs_check_installer_sig: "${{ inputs.check-installer-sig }}"
+        inputs_work_vol: "${{ inputs.work-vol }}"
       run: |
-        $ErrorActionPreference = 'Stop'
-        $platform = '${{ inputs.platform }}'
-        $platform = $platform -replace '^(x64|amd64)$', 'x86_64'
-        $platform = $platform -replace '^i686$', 'x86'
-        # validate that platform is one of the expected values
-        if (($platform -ne 'x86') -and ($platform -ne 'x86_64')) {
-          throw "Unknown platform $platform."
-        }
-
-        $vol = '${{ inputs.work-vol }}'
-        # If temporary drive D: doesn't exist in the VM, fallback to C:
-        if ("$vol" -eq '') {
-          if (Test-Path -LiteralPath 'D:\') {
-            $vol = 'D:'
-            } else {
-            $vol = 'C:'
-            }
-        }
-
-        $setupExe = "$vol\setup.exe"
-        $setupFileName = "setup-$platform.exe"
-
-        function Invoke-WebRequest-With-Retry {
-          param (
-            $Uri,
-            $OutFile
-          )
-
-          $maxRetries = 5
-          $retryCount = 0
-          $success = $false
-          $delay = 2
-
-          while (-not $success -and $retryCount -lt $maxRetries) {
-            try {
-              Invoke-WebRequest -Uri $Uri -OutFile $OutFile
-              $success = $true
-            } catch [System.Net.WebException] {
-              Write-Output "Attempt $($retryCount + 1) failed. Retrying..."
-              Start-Sleep -Seconds $delay
-              $retryCount++
-              $delay += $delay
-            }
-          }
-
-          if (-not $success) {
-            throw "Failed to download $setupFileName after $maxRetries attempts."
-          }
-        }
-
-        Invoke-WebRequest-With-Retry "https://cygwin.com/$setupFileName" $setupExe
-
-        if ((Get-Item -LiteralPath $setupExe).Length -eq 0) {
-          throw "The downloaded setup has a zero length!"
-        }
-
-        $signature = Get-AuthenticodeSignature -FilePath $setupExe
-        echo "Signature status: $($signature.Status) fingerprint: $($signature.SignerCertificate.GetCertHashString("SHA256"))"
-        # TBD: this should check against a list of fingerprints for valid certs we have used
-        if (!$signature.Status -ne 'Valid' -or $signature.SignerCertificate.GetCertHashString("SHA256") -ne '2ce11da3a675a9d631e06a28ddfd6f730b9cc6989b43bd30ad7cc79d219cf2bd') {
-          if ('${{ inputs.check-installer-sig }}' -eq 'true') {
-              throw "Invalid CodeSign signature on the downloaded setup!"
-          }
-        }
-
-        if ('${{ inputs.check-hash }}' -eq 'true') {
-          $hashFile = "$vol\sha512.sum"
-          Invoke-WebRequest-With-Retry https://cygwin.com/sha512.sum $hashFile
-          $expectedHashLines = Get-Content $hashFile
-          $expectedHash = ''
-          foreach ($expectedHashLine in $expectedHashLines) {
-            if ($expectedHashLine.EndsWith(" $setupFileName")) {
-              $expectedHash = $($expectedHashLine -split '\s+')[0]
-              break
-            }
-          }
-          if ($expectedHash -eq '') {
-            Write-Output -InputObject "::warning::Unable to find the hash for the file $setupFileName in https://cygwin.com/sha512.sum"
-          } else {
-            $actualHash = $(Get-FileHash -LiteralPath $setupExe -Algorithm SHA512).Hash
-            if ($actualHash -ine $expectedHash) {
-              throw "Invalid hash of the downloaded setup!`nExpected: $expectedHash`nActual  : $actualHash"
-            } else {
-              Write-Output -InputObject "The downloaded file has the expected hash ($expectedHash)"
-            }
-          }
-        }
-
-        $installDir = "$vol\cygwin"
-        if ('${{ inputs.install-dir }}' -ne '') {
-          $installDir = '${{ inputs.install-dir }}'
-        }
-
-        $packageDir = "$vol\cygwin-packages"
-
-        $packages = '${{ inputs.packages }}'
-        $pkg_list = $packages.Split('', [System.StringSplitOptions]::RemoveEmptyEntries)
-        $pkg_list = $pkg_list | % { $_.Trim() }
-        $pkg_list = $pkg_list | % { $_.Trim(',') }
-
-        $args = @(
-         '-qnO',
-         '-l', "$packageDir",
-         '-R', "$installDir"
-        )
-
-        if ( '${{ inputs.allow-test-packages }}' -eq 'true' ) {
-          $args += '-t' # --allow-test-packages
-        }
-
-        # default site if not specified
-        if ( '${{ inputs.site }}' ) {
-          $sites = '${{ inputs.site }}'
-        } elseif ($platform -eq 'x86') {
-          $sites = 'http://mirrors.kernel.org/sourceware/cygwin-archive/20221123'
-        } else {
-          $sites = 'http://mirrors.kernel.org/sourceware/cygwin/'
-        }
-        $site_list = $sites.Split('', [System.StringSplitOptions]::RemoveEmptyEntries)
-        $site_list = $site_list | % { $_.Trim() }
-        foreach ($site in $site_list) {
-          $args += '-s'
-          $args += $site
-        }
-
-        if ($pkg_list.Count -gt 0) {
-          $args += '-P'
-          $args += $pkg_list -Join(',')
-        }
-
-        if ('${{ inputs.check-sig }}' -eq $false) {
-          $args += '-X'
-        }
-
-        if ( '${{ inputs.pubkeys }}' ) {
-          $pubkeys = '${{ inputs.pubkeys }}'
-          $pubkey_list = $pubkeys.Split('', [System.StringSplitOptions]::RemoveEmptyEntries)
-          $pubkey_list = $pubkey_list | % { $_.Trim() }
-          foreach ($pubkey in $pubkey_list) {
-            $args += '-K'
-            $args += $pubkey
-          }
-        }
-
-        if ($platform -eq 'x86') {
-          $args += '--allow-unsupported-windows'
-        }
-
-        # because setup is a Windows GUI app, make it part of a pipeline to make
-        # PowerShell wait for it to exit
-        & $setupExe $args | Out-Default
-
-        if ('${{ inputs.work-vol }}' -eq '' -and '${{ inputs.install-dir }}' -eq '') {
-          # Create a symlink for compatibility with previous versions of this
-          # action, just in case something relies upon C:\cygwin existing
-          cmd /c mklink /d C:\cygwin $installDir
-        }
-
-        if ('${{ inputs.add-to-path }}' -eq 'true') {
-          echo "$installDir\bin" >> $env:GITHUB_PATH
-        }
-
-        # run login shell to copy skeleton profile files
-        & "$installDir\bin\bash.exe" --login
-
-        # set outputs
-        echo "setup=$setupExe" >> $env:GITHUB_OUTPUT
-        echo "root=$installDir" >> $env:GITHUB_OUTPUT
-        echo "package-cache=$packageDir" >> $env:GITHUB_OUTPUT
-
+        & $Env:GITHUB_ACTION_PATH\src\install.ps1
       shell: powershell
 
 branding:

--- a/src/install.ps1
+++ b/src/install.ps1
@@ -1,0 +1,169 @@
+$ErrorActionPreference = 'Stop'
+$platform = "$env:inputs_platform"
+$platform = $platform -replace '^(x64|amd64)$', 'x86_64'
+$platform = $platform -replace '^i686$', 'x86'
+# validate that platform is one of the expected values
+if (($platform -ne 'x86') -and ($platform -ne 'x86_64')) {
+    throw "Unknown platform $platform."
+}
+
+$vol = "$env:inputs_work_vol"
+# If temporary drive D: doesn't exist in the VM, fallback to C:
+if ("$vol" -eq '') {
+    if (Test-Path -LiteralPath 'D:\') {
+        $vol = 'D:'
+        } else {
+        $vol = 'C:'
+        }
+}
+
+$setupExe = "$vol\setup.exe"
+$setupFileName = "setup-$platform.exe"
+
+function Invoke-WebRequest-With-Retry {
+    param (
+        $Uri,
+        $OutFile
+    )
+
+    $maxRetries = 5
+    $retryCount = 0
+    $success = $false
+    $delay = 2
+
+    while (-not $success -and $retryCount -lt $maxRetries) {
+        try {
+            Invoke-WebRequest -Uri $Uri -OutFile $OutFile
+            $success = $true
+        } catch [System.Net.WebException] {
+            Write-Output "Attempt $($retryCount + 1) failed. Retrying..."
+            Start-Sleep -Seconds $delay
+            $retryCount++
+            $delay += $delay
+        }
+    }
+
+    if (-not $success) {
+        throw "Failed to download $setupFileName after $maxRetries attempts."
+    }
+}
+
+Invoke-WebRequest-With-Retry "https://cygwin.com/$setupFileName" $setupExe
+
+if ((Get-Item -LiteralPath $setupExe).Length -eq 0) {
+    throw "The downloaded setup has a zero length!"
+}
+
+$signature = Get-AuthenticodeSignature -FilePath $setupExe
+echo "Signature status: $($signature.Status) fingerprint: $($signature.SignerCertificate.GetCertHashString("SHA256"))"
+# TBD: this should check against a list of fingerprints for valid certs we have used
+if (!$signature.Status -ne 'Valid' -or $signature.SignerCertificate.GetCertHashString("SHA256") -ne '2ce11da3a675a9d631e06a28ddfd6f730b9cc6989b43bd30ad7cc79d219cf2bd') {
+    if ("$env:inputs_check_installer_sig" -eq 'true') {
+            throw "Invalid CodeSign signature on the downloaded setup!"
+    }
+}
+
+if ("$env:inputs_check_hash" -eq 'true') {
+    $hashFile = "$vol\sha512.sum"
+    Invoke-WebRequest-With-Retry https://cygwin.com/sha512.sum $hashFile
+    $expectedHashLines = Get-Content $hashFile
+    $expectedHash = ''
+    foreach ($expectedHashLine in $expectedHashLines) {
+        if ($expectedHashLine.EndsWith(" $setupFileName")) {
+            $expectedHash = $($expectedHashLine -split '\s+')[0]
+            break
+        }
+    }
+    if ($expectedHash -eq '') {
+        Write-Output -InputObject "::warning::Unable to find the hash for the file $setupFileName in https://cygwin.com/sha512.sum"
+    } else {
+        $actualHash = $(Get-FileHash -LiteralPath $setupExe -Algorithm SHA512).Hash
+        if ($actualHash -ine $expectedHash) {
+            throw "Invalid hash of the downloaded setup!`nExpected: $expectedHash`nActual  : $actualHash"
+        } else {
+            Write-Output -InputObject "The downloaded file has the expected hash ($expectedHash)"
+        }
+    }
+}
+
+$installDir = "$vol\cygwin"
+if ("$env:inputs_install_dir" -ne '') {
+    $installDir = "$env:inputs_install_dir"
+}
+
+$packageDir = "$vol\cygwin-packages"
+
+$packages = "$env:inputs_packages"
+$pkg_list = $packages.Split('', [System.StringSplitOptions]::RemoveEmptyEntries)
+$pkg_list = $pkg_list | % { $_.Trim() }
+$pkg_list = $pkg_list | % { $_.Trim(',') }
+
+$args = @(
+ '-qnO',
+ '-l', "$packageDir",
+ '-R', "$installDir"
+)
+
+if ( "$env:inputs_allow_test_packages" -eq 'true' ) {
+    $args += '-t' # --allow-test-packages
+}
+
+# default site if not specified
+if ( "$env:inputs_site" ) {
+    $sites = "$env:inputs_site"
+} elseif ($platform -eq 'x86') {
+    $sites = 'http://mirrors.kernel.org/sourceware/cygwin-archive/20221123'
+} else {
+    $sites = 'http://mirrors.kernel.org/sourceware/cygwin/'
+}
+$site_list = $sites.Split('', [System.StringSplitOptions]::RemoveEmptyEntries)
+$site_list = $site_list | % { $_.Trim() }
+foreach ($site in $site_list) {
+    $args += '-s'
+    $args += $site
+}
+
+if ($pkg_list.Count -gt 0) {
+    $args += '-P'
+    $args += $pkg_list -Join(',')
+}
+
+if ("$env:inputs_check_sig" -eq $false) {
+    $args += '-X'
+}
+
+if ( "$env:inputs_pubkeys" ) {
+    $pubkeys = "$env:inputs_pubkeys"
+    $pubkey_list = $pubkeys.Split('', [System.StringSplitOptions]::RemoveEmptyEntries)
+    $pubkey_list = $pubkey_list | % { $_.Trim() }
+    foreach ($pubkey in $pubkey_list) {
+        $args += '-K'
+        $args += $pubkey
+    }
+}
+
+if ($platform -eq 'x86') {
+    $args += '--allow-unsupported-windows'
+}
+
+# because setup is a Windows GUI app, make it part of a pipeline to make
+# PowerShell wait for it to exit
+& $setupExe $args | Out-Default
+
+if ("$env:inputs_work_vol" -eq '' -and "$env:inputs_install_dir" -eq '') {
+    # Create a symlink for compatibility with previous versions of this
+    # action, just in case something relies upon C:\cygwin existing
+    cmd /c mklink /d C:\cygwin $installDir
+}
+
+if ("$env:inputs_add_to_path" -eq 'true') {
+    echo "$installDir\bin" >> $env:GITHUB_PATH
+}
+
+# run login shell to copy skeleton profile files
+& "$installDir\bin\bash.exe" --login
+
+# set outputs
+echo "setup=$setupExe" >> $env:GITHUB_OUTPUT
+echo "root=$installDir" >> $env:GITHUB_OUTPUT
+echo "package-cache=$packageDir" >> $env:GITHUB_OUTPUT


### PR DESCRIPTION
This allows developers to work with syntax highlighting; it allows linters to check for syntax errors and style issues; and it allows for the development of a test suite using Powershell tools like e.g. Pester.

As a part of this change, `${{ inputs.* }}` references were replaced. The script now relies on environment variables named `inputs_*`.

When CI ran in my fork, [the changes passed the tests](https://github.com/kurtmckee/pr-cygwin-install-action/actions/runs/20421267129/job/58673487704).

----

Thanks for your work on `cygwin-install-action`, it's been helpful for me to test Python projects under Cygwin!