### PR TITLE
Update `actions/checkout` versions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "quarterly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
     - run: git config --global core.autocrlf input
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
     - name: Install Cygwin
       uses: ./
@@ -88,7 +88,7 @@ jobs:
     - run: git config --global core.autocrlf input
       shell: pwsh -command ". '{0}'".
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
     - name: Install Cygwin
       uses: ./
@@ -127,7 +127,7 @@ jobs:
     steps:
     - run: git config --global core.autocrlf input
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
     - name: Install Cygwin
       uses: ./
@@ -167,7 +167,7 @@ jobs:
     steps:
     - run: git config --global core.autocrlf input
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
     - name: Install Cygwin
       uses: ./
@@ -210,7 +210,7 @@ jobs:
     steps:
     - run: git config --global core.autocrlf input
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
     - name: Install Cygwin
       uses: ./
@@ -228,7 +228,7 @@ jobs:
     steps:
     - run: git config --global core.autocrlf input
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
     - name: Install Cygwin
       uses: ./
@@ -251,7 +251,7 @@ jobs:
     steps:
     - run: git config --global core.autocrlf input
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
     - name: Fail to install Cygwin
       uses: ./
@@ -283,7 +283,7 @@ jobs:
     steps:
     - run: git config --global core.autocrlf input
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
     - name: Run repo HTTP server
       uses: Eun/http-server-action@v1.0.6
@@ -310,7 +310,7 @@ jobs:
     steps:
     - run: git config --global core.autocrlf input
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
     - name: Install Cygwin
       id: cygwin-install

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ e.g.
 
     - run: git config --global core.autocrlf input
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - uses: cygwin/cygwin-install-action@master
 


### PR DESCRIPTION
This introduces the following changes:

* Update `actions/checkout` to v6.0.1
* Pin to commit SHAs for reproducibility and security
* Update the example YAML workflow in the README
* Introduce a Dependabot config

  Dependabot will submit PRs on a quarterly basis to update action versions as needed.