### PR TITLE
Introduce Pester for testing `install.ps1` behavior

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -341,3 +341,13 @@ jobs:
         SETUP: ${{ steps.cygwin-install.outputs.setup }}
         ROOT: ${{ steps.cygwin-install.outputs.root }}
         CACHE: ${{ steps.cygwin-install.outputs.package-cache }}
+
+  pester:
+    name: "Pester test suite"
+    runs-on: "windows-latest"
+    steps:
+      - name: "Checkout the repository"
+        uses: "actions/checkout@v6"
+      - name: "Run Pester"
+        run: |
+          Invoke-Pester -Output Detailed ./tests

--- a/src/_functions.ps1
+++ b/src/_functions.ps1
@@ -1,0 +1,22 @@
+function Get-Validated-Platform {
+    param (
+        $Platform
+    )
+
+    switch ($platform) {
+        # Valid values
+        'x86_64'    { return 'x86_64'   }
+        'x86'       { return 'x86'      }
+
+        # Default value
+        ''          { return 'x86_64'   }
+
+        # Backwards-compatibility strings
+        'x64'       { return 'x86_64'   }
+        'amd64'     { return 'x86_64'   }
+        'i686'      { return 'x86'      }
+
+        # Unrecognized platform
+        default     { throw "Unknown platform $Platform." }
+    }
+}

--- a/src/install.ps1
+++ b/src/install.ps1
@@ -1,11 +1,9 @@
 $ErrorActionPreference = 'Stop'
-$platform = "$env:inputs_platform"
-$platform = $platform -replace '^(x64|amd64)$', 'x86_64'
-$platform = $platform -replace '^i686$', 'x86'
-# validate that platform is one of the expected values
-if (($platform -ne 'x86') -and ($platform -ne 'x86_64')) {
-    throw "Unknown platform $platform."
-}
+
+# Import functions.
+. "$PSScriptRoot/_functions.ps1"
+
+$platform = Get-Validated-Platform -Platform "$env:inputs_platform"
 
 $vol = "$env:inputs_work_vol"
 # If temporary drive D: doesn't exist in the VM, fallback to C:

--- a/tests/Get-Validated-Platform.Tests.ps1
+++ b/tests/Get-Validated-Platform.Tests.ps1
@@ -1,0 +1,38 @@
+BeforeAll {
+    . "$PSScriptRoot/../src/_functions.ps1"
+}
+
+Describe 'Get-Validated-Platform' {
+    Context 'canonical strings' {
+        It 'x86_64' {
+            Get-Validated-Platform -Platform 'x86_64' | Should -Be 'x86_64'
+        }
+        It 'x86' {
+            Get-Validated-Platform -Platform 'x86' | Should -Be 'x86'
+        }
+    }
+
+    Context 'backwards-compatibility strings' {
+        It 'amd64' {
+            Get-Validated-Platform -Platform 'amd64' | Should -Be 'x86_64'
+        }
+        It 'i686' {
+            Get-Validated-Platform -Platform 'i686' | Should -Be 'x86'
+        }
+        It 'x64' {
+            Get-Validated-Platform -Platform 'x64' | Should -Be 'x86_64'
+        }
+    }
+
+    Context 'default value' {
+        It 'default value' {
+            Get-Validated-Platform -Platform '' | Should -Be 'x86_64'
+        }
+    }
+
+    Context 'unknown value' {
+        It 'unknown value' {
+            { Get-Validated-Platform -Platform 'bogus' } | Should -Throw 'Unknown platform bogus.'
+        }
+    }
+}


### PR DESCRIPTION
This introduces the following changes:

* Move the `platform` parameter validation to a `Get-Validated-Platform` function.
* Introduce [Pester](https://pester.dev/)-based testing of the function.
* Add a CI job to run the Pester test suite. [[example run](https://github.com/kurtmckee/pr-cygwin-install-action/actions/runs/20492897418/job/58888095018)]

This commit simply introduces the testing framework upon which subsequent work can build. It should now be possible to fix more bugs in -- and then test! -- `install.ps1` behavior.

Here's an example of what the Pester test suite looks like when run in CI:

> <img width="897" height="648" alt="image" src="https://github.com/user-attachments/assets/9274067a-15fb-4950-9bef-079f498428cd" />
