### PR TITLE
Fail installation if setup returns a non-zero exit code

### DIFF
--- a/src/_functions.ps1
+++ b/src/_functions.ps1
@@ -20,3 +20,21 @@ function Get-Validated-Platform {
         default     { throw "Unknown platform $Platform." }
     }
 }
+
+
+function Invoke-Cygwin-Setup {
+    param (
+        $SetupExePath,
+        $SetupExeArgs
+    )
+
+    # Because setup is a Windows GUI app, make it part of a pipeline
+    # to make PowerShell wait for it to exit.
+    Write-Host $SetupExePath $SetupExeArgs
+    & $SetupExePath $SetupExeArgs | Out-Default
+
+    # Check the exit code.
+    if ($LASTEXITCODE -ne 0) {
+        throw "$SetupExePath exited with error code $LASTEXITCODE"
+    }
+}

--- a/src/install.ps1
+++ b/src/install.ps1
@@ -144,9 +144,7 @@ if ($platform -eq 'x86') {
     $args += '--allow-unsupported-windows'
 }
 
-# because setup is a Windows GUI app, make it part of a pipeline to make
-# PowerShell wait for it to exit
-& $setupExe $args | Out-Default
+Invoke-Cygwin-Setup -SetupExePath $setupExe -SetupExeArgs $args
 
 if ("$env:inputs_work_vol" -eq '' -and "$env:inputs_install_dir" -eq '') {
     # Create a symlink for compatibility with previous versions of this

--- a/tests/Invoke-Cygwin-Setup.Tests.ps1
+++ b/tests/Invoke-Cygwin-Setup.Tests.ps1
@@ -1,0 +1,15 @@
+BeforeAll {
+    . "$PSScriptRoot/../src/_functions.ps1"
+}
+
+Describe 'Invoke-Cygwin-Setup' {
+    It 'success' {
+        $arguments = @('-Command', 'Write-Host "success"')
+        Invoke-Cygwin-Setup -SetupExePath 'pwsh' -SetupExeArgs $arguments | Should -Be $null
+    }
+
+    It 'non-zero exit code' {
+        $arguments = @('-Command', 'throw "error!"')
+        { Invoke-Cygwin-Setup -SetupExePath 'pwsh' -SetupExeArgs $arguments } | Should -Throw "*exited with error code 1"
+    }
+}


### PR DESCRIPTION
This PR introduces the following changes:

* Check the setup exit code and throw an exception if it is non-zero.
* Move setup invocation to a function. Testing can be added after #41 merges.
* Write the full command to STDOUT for debugging about the setup command and arguments that will be run.

It was tested locally by importing the function and invoking it with a local command and args. Success and failure cases were both checked.

Fixes #40