### PR TITLE
Validate the `work-vol` parameter

### DIFF
--- a/src/_functions.ps1
+++ b/src/_functions.ps1
@@ -38,3 +38,35 @@ function Invoke-Cygwin-Setup {
         throw "$SetupExePath exited with error code $LASTEXITCODE"
     }
 }
+
+
+function Get-Validated-Work-Volume {
+    param (
+        $WorkVolume
+    )
+
+    # Prefer the user's chosen volume.
+    if ("$WorkVolume" -ne '') {
+        if ("$WorkVolume" -notmatch '^[A-Za-z]:$') {
+            throw "The work-vol parameter, '$WorkVolume', must be only a drive letter and a colon, like 'D:'."
+        }
+        if (-Not (Test-Path -LiteralPath "$WorkVolume\")) {
+            throw "The work-vol parameter, '$WorkVolume', is not a valid drive."
+        }
+        return "$WorkVolume".ToUpper()
+    }
+
+    # Prefer the 'D:' drive but fall back to SYSTEMDRIVE.
+    # 'D:' is preferred on hosted runners for performance reasons.
+    if (Test-Path -LiteralPath 'D:\') {
+        return 'D:'
+    }
+
+    return Get-SystemDrive
+}
+
+
+# ---------------------------------------------------------------------
+# Functions below this line exist so the test suite can mock them.
+
+function Get-SystemDrive { "$Env:SYSTEMDRIVE" }

--- a/src/install.ps1
+++ b/src/install.ps1
@@ -4,16 +4,7 @@ $ErrorActionPreference = 'Stop'
 . "$PSScriptRoot/_functions.ps1"
 
 $platform = Get-Validated-Platform -Platform "$env:inputs_platform"
-
-$vol = "$env:inputs_work_vol"
-# If temporary drive D: doesn't exist in the VM, fallback to C:
-if ("$vol" -eq '') {
-    if (Test-Path -LiteralPath 'D:\') {
-        $vol = 'D:'
-        } else {
-        $vol = 'C:'
-        }
-}
+$vol = Get-Validated-Work-Volume -WorkVolume "$env:inputs_work_vol"
 
 $setupExe = "$vol\setup.exe"
 $setupFileName = "setup-$platform.exe"

--- a/tests/Get-Validated-Work-Volume.Tests.ps1
+++ b/tests/Get-Validated-Work-Volume.Tests.ps1
@@ -1,0 +1,38 @@
+BeforeAll {
+    . "$PSScriptRoot/../src/_functions.ps1"
+}
+
+Describe 'Get-Validated-Work-Volume' {
+    Context '-WorkVolume parameter' {
+        It 'Wrong format' {
+            Mock Test-Path { $false }
+            { Get-Validated-Work-Volume -WorkVolume 'A:\' } | Should -Throw "*must be only a drive letter and a colon*"
+        }
+        It 'Does not exist' {
+            Mock Test-Path { $false }
+            { Get-Validated-Work-Volume -WorkVolume 'A:' } | Should -Throw "*not a valid drive*"
+        }
+        It 'Lowercase success' {
+            Mock Test-Path { $true }
+            Get-Validated-Work-Volume -WorkVolume 'a:' | Should -Be "A:"
+        }
+        It 'Uppercase success' {
+            Mock Test-Path { $true }
+            Get-Validated-Work-Volume -WorkVolume 'A:' | Should -Be "A:"
+        }
+    }
+
+    It 'D: drive default' {
+        Mock Test-Path { $true }
+        Get-Validated-Work-Volume | Should -Be 'D:'
+    }
+
+    It 'Fallback to SYSTEMDRIVE' {
+        # Setup
+        Mock Test-Path { $false }
+        Mock Get-SystemDrive { 'A:' }
+
+        # Verify
+        Get-Validated-Work-Volume | Should -Be 'A:'
+    }
+}


### PR DESCRIPTION
This introduces the following changes:

* Validate the format of the `work-vol` parameter.

  Previously, arbitrary strings could be used.

* Verify the `work-vol` parameter is a valid path.

  Previously, this was not verified at runtime.

* Fallback to `$Env:SYSTEMDRIVE`, not simply `'C:'`.

  Although it's likely that the system drive is `'C:'`, this is no longer assumed by the script.