### PR TITLE
Test splitting of the site list

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,19 +23,19 @@ e.g.
 Parameters
 ----------
 
-| Input               | Default                                      | Description
-| ------------------- | -------------------------------------------- | -----------
-| platform            | x86_64                                       | Install the x86\_64 or x86 [^1] version of Cygwin.
-| packages            | *none*                                       | List of additional packages to install.
-| install-dir         | D:\cygwin                                    | Installation directory (overrides work-vol)
-| site                | http://mirrors.kernel.org/sourceware/cygwin/ | Mirror sites to install from, separated by whitespace
-| pubkeys             | *none*                                       | Absolute paths of extra public key files (RFC4880 format), separated by whitespace
-| check-sig           | true                                         | Whether to check the setup.ini signature
-| add-to-path         | true                                         | Whether to add Cygwin's `/bin` directory to the system `PATH`
-| allow-test-packages | false                                        | Consider package versions marked test for installation
-| check-hash          | true                                         | Whether to check the hash of the downloaded Cygwin installer.
-| check-installer-sig | true                                         | Whether to check the Authenticode signature of the downloaded Cygwin installer.
-| work-vol            | D:                                           | Volume on which to store setup and packages, and install Cygwin.
+| Input               | Default                                         | Description
+| ------------------- |-------------------------------------------------| -----------
+| platform            | x86_64                                          | Install the x86\_64 or x86 [^1] version of Cygwin.
+| packages            | *none*                                          | List of additional packages to install.
+| install-dir         | D:\cygwin                                       | Installation directory (overrides work-vol)
+| site                | `https://mirrors.kernel.org/sourceware/cygwin/` | Mirror sites to install from, separated by whitespace
+| pubkeys             | *none*                                          | Absolute paths of extra public key files (RFC4880 format), separated by whitespace
+| check-sig           | true                                            | Whether to check the setup.ini signature
+| add-to-path         | true                                            | Whether to add Cygwin's `/bin` directory to the system `PATH`
+| allow-test-packages | false                                           | Consider package versions marked test for installation
+| check-hash          | true                                            | Whether to check the hash of the downloaded Cygwin installer.
+| check-installer-sig | true                                            | Whether to check the Authenticode signature of the downloaded Cygwin installer.
+| work-vol            | D:                                              | Volume on which to store setup and packages, and install Cygwin.
 
 Line endings
 ------------

--- a/src/_functions.ps1
+++ b/src/_functions.ps1
@@ -22,6 +22,24 @@ function Get-Validated-Platform {
 }
 
 
+function Get-Validated-Sites {
+    param (
+        $Platform,
+        $Sites
+    )
+
+    if ("$Sites" -eq '') {
+        switch ("$Platform") {
+            'x86'   { return @( 'https://mirrors.kernel.org/sourceware/cygwin-archive/20221123' ) }
+            # This is the default site for x86_64 platforms.
+            default { return @( 'https://mirrors.kernel.org/sourceware/cygwin/' ) }
+        }
+    }
+
+    return "$Sites" -Split '\s+' | Where-Object { $_ }
+}
+
+
 function Invoke-Cygwin-Setup {
     param (
         $SetupExePath,

--- a/src/install.ps1
+++ b/src/install.ps1
@@ -106,16 +106,7 @@ if ( "$env:inputs_allow_test_packages" -eq 'true' ) {
     $args += '-t' # --allow-test-packages
 }
 
-# default site if not specified
-if ( "$env:inputs_site" ) {
-    $sites = "$env:inputs_site"
-} elseif ($platform -eq 'x86') {
-    $sites = 'http://mirrors.kernel.org/sourceware/cygwin-archive/20221123'
-} else {
-    $sites = 'http://mirrors.kernel.org/sourceware/cygwin/'
-}
-$site_list = $sites.Split('', [System.StringSplitOptions]::RemoveEmptyEntries)
-$site_list = $site_list | % { $_.Trim() }
+$site_list = Get-Validated-Sites -Platform "$platform" -Sites "$env:inputs_site"
 foreach ($site in $site_list) {
     $args += '-s'
     $args += $site

--- a/tests/Get-Validated-Sites.Tests.ps1
+++ b/tests/Get-Validated-Sites.Tests.ps1
@@ -1,0 +1,30 @@
+BeforeAll {
+    . "$PSScriptRoot/../src/_functions.ps1"
+}
+
+Describe 'Get-Validated-Sites' {
+    Context 'Platform defaults' {
+        It 'Default (x86_64)' {
+            $sites = Get-Validated-Sites
+            Should -ActualValue $sites -Be @( 'https://mirrors.kernel.org/sourceware/cygwin/' )
+        }
+        It 'x86' {
+            $sites = Get-Validated-Sites -Platform 'x86'
+            Should -ActualValue $sites -Be @( 'https://mirrors.kernel.org/sourceware/cygwin-archive/20221123' )
+        }
+    }
+
+    Context 'Custom sites' {
+        It 'Single value' {
+            Get-Validated-Sites -Sites 'a' | Should -Be @( 'a' )
+        }
+
+        It 'Spaces' {
+            Get-Validated-Sites -Sites ' a b ' | Should -Be @( 'a', 'b' )
+        }
+
+        It 'Newlines and tabs' {
+            Get-Validated-Sites -Sites "`n`ta`n`tb`n`t" | Should -Be @( 'a', 'b' )
+        }
+    }
+}


### PR DESCRIPTION
This introduces the following changes:

* Test the code that splits and standardizes the `site` parameter.
* Migrate from HTTP to HTTPS for the default sites.