### PR TITLE
Remove `fail-fast` directives with no associated `matrix`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -220,9 +220,6 @@ jobs:
 
   time-machine:
     runs-on: windows-latest
-    strategy:
-      fail-fast: false
-
     name: 'Test time machine signature'
 
     steps:
@@ -243,9 +240,6 @@ jobs:
 
   bad-sig:
     runs-on: windows-latest
-    strategy:
-      fail-fast: false
-
     name: 'Test failure of time machine signature'
 
     steps:
@@ -275,9 +269,6 @@ jobs:
 
   multiple-sites-and-pubkeys:
     runs-on: windows-latest
-    strategy:
-      fail-fast: false
-
     name: 'Test multiple sites and extra pubkeys'
 
     steps:


### PR DESCRIPTION
`fail-fast` only applies in the context of a `matrix` of jobs, where the desired behavior is for _any_ failure to halt the entire matrix of jobs.

When there is no `matrix`, `fail-fast` doesn't apply, and IDEs and linters throw warnings (which is how this issue ended up on my radar). 