### PR TITLE
Fail when packages cannot be found

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -293,6 +293,35 @@ jobs:
     - name: Run test shell script
       run: C:\cygwin\bin\bash.exe /cygwin-install-action-test.sh
 
+  error-on-missing-packages-default:
+    name: 'Test `error-on-missing-packages`: default'
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+    - name: 'Install Cygwin (expect failure)'
+      id: 'install-expects-failure'
+      continue-on-error: true
+      uses: ./
+      with:
+        packages: Http404PackageDoesNotExist
+    - name: 'Verify action failure'
+      if: "${{ steps.install-expects-failure.outcome != 'failure' }}"
+      shell: 'bash'
+      run: |
+        echo '::error::The action did not fail when missing packages were detected!'
+        exit 1
+
+  error-on-missing-packages-disabled:
+    name: 'Test `error-on-missing-packages`: false'
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+    - name: 'Install Cygwin (expect warning)'
+      uses: ./
+      with:
+        error-on-missing-packages: 'false'
+        packages: Http404PackageDoesNotExist
+
   outputs-test:
     runs-on: windows-latest
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Table of Contents
 * [Inputs](#inputs)
 
   * [`packages`](#packages)
+  * [`error-on-missing-packages`](#error-on-missing-packages)
   * [`allow-test-packages`](#allow-test-packages)
   * [`work-vol`](#work-vol)
   * [`install-dir`](#install-dir)
@@ -71,6 +72,26 @@ Example usage:
       git
       python3
       python3-pip
+```
+
+### `error-on-missing-packages`
+
+By default, if any packages in the [`packages`](#packages) input
+cannot be found, the action will fail.
+
+Errors can be downgraded to warnings by setting this input to `'false'`.
+This may be useful when Cygwin transitions from one package to another
+for equivalent functionality.
+
+Example usage:
+
+```yaml
+- uses: 'cygwin/cygwin-install-action@<version>'
+  with:
+    packages: |
+      package10
+      alternate-package10
+    error-on-missing-packages: 'false'
 ```
 
 ### `allow-test-packages`

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,14 @@ inputs:
   packages:
     description: Packages to install
     required: false
+  error-on-missing-packages:
+    description: |
+      By default, all packages listed in the `packages` input must install successfully.
+      If any packages fail to install for any reason, the action will fail with an error.
+
+      Setting this to "false" downgrades errors to warnings to allow the action to succeed.
+    required: false
+    default: 'true'
   install-dir:
     # For consistency and simplicity, install to <work-dir>:\cygwin rather
     # than to the platform dependent default (e.g. <work-dir>:\cygwin64)
@@ -64,6 +72,7 @@ runs:
       env:
         inputs_platform: "${{ inputs.platform }}"
         inputs_packages: "${{ inputs.packages }}"
+        inputs_error_on_missing_packages: "${{ inputs.error-on-missing-packages }}"
         inputs_install_dir: "${{ inputs.install-dir }}"
         inputs_check_sig: "${{ inputs.check-sig }}"
         inputs_pubkeys: "${{ inputs.pubkeys }}"

--- a/src/install.ps1
+++ b/src/install.ps1
@@ -5,6 +5,7 @@ $ErrorActionPreference = 'Stop'
 
 $platform = Get-Validated-Platform -Platform "$env:inputs_platform"
 $vol = Get-Validated-Work-Volume -WorkVolume "$env:inputs_work_vol"
+$error_on_missing_packages = Get-Validated-Error-On-Missing-Packages -Value "$env:inputs_error_on_missing_packages"
 
 $setupExe = "$vol\setup.exe"
 $setupFileName = "setup-$platform.exe"
@@ -126,7 +127,7 @@ if ($platform -eq 'x86') {
     $args += '--allow-unsupported-windows'
 }
 
-Invoke-Cygwin-Setup -SetupExePath $setupExe -SetupExeArgs $args
+Invoke-Cygwin-Setup -SetupExePath $setupExe -SetupExeArgs $args -ErrorOnMissingPackages $error_on_missing_packages
 
 if ("$env:inputs_work_vol" -eq '' -and "$env:inputs_install_dir" -eq '') {
     # Create a symlink for compatibility with previous versions of this

--- a/tests/Invoke-Cygwin-Setup.Tests.ps1
+++ b/tests/Invoke-Cygwin-Setup.Tests.ps1
@@ -12,4 +12,15 @@ Describe 'Invoke-Cygwin-Setup' {
         $arguments = @('-Command', 'throw "error!"')
         { Invoke-Cygwin-Setup -SetupExePath 'pwsh' -SetupExeArgs $arguments } | Should -Throw "*exited with error code 1"
     }
+
+    It 'can warn on missing packages' {
+        $arguments = @('-Command', 'Write-Host', "setup had a problem``nPackage 'xyz' not found.``nother text")
+        $output = Invoke-Cygwin-Setup -SetupExePath 'pwsh' -SetupExeArgs $arguments -ErrorOnMissingPackages "false"
+        Should -ActualValue $output -Match '::warning::One or more packages could not be found'
+    }
+
+    It 'can error on missing packages' {
+        $arguments = @('-Command', 'Write-Host', "setup had a problem``nPackage 'xyz' not found.``nother text")
+        { Invoke-Cygwin-Setup -SetupExePath 'pwsh' -SetupExeArgs $arguments -ErrorOnMissingPackages "true" } | Should -Throw "One or more packages could not be found"
+    }
 }


### PR DESCRIPTION
This introduces a new `error-on-missing-packages` input, which defaults to true. This is a breaking change.

Currently, only the phrase `"Package 'xyz' not found."` is searched for in the output of the install. The documentation of the new input leaves room for additional reasons for a missing package to be added.

Closes cygwin/cygwin-install-action#20