### PR TITLE
[ci] Update GitHub Action Eun/http-server-action used in test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -277,7 +277,7 @@ jobs:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Run repo HTTP server
-      uses: Eun/http-server-action@f71cec1321f665652a46c40b6852f8e5a68bfcd4 # v1.0.12
+      uses: Eun/http-server-action@dadebd209d4a902eeefceb524c24c38b364c46a7 # v1.0.13
       with:
         directory: ${{ github.workspace }}\tests\repo
 


### PR DESCRIPTION
Fixes Node20.js deprecation warning indicating it will stop working in June.