### PR TITLE
Add a package-cache dir input

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -337,6 +337,53 @@ jobs:
         ROOT: ${{ steps.cygwin-install.outputs.root }}
         CACHE: ${{ steps.cygwin-install.outputs.package-cache }}
 
+  package-cache-test:
+    runs-on: windows-latest
+
+    name: 'Package caching example'
+
+    steps:
+    - run: git config --global core.autocrlf input
+
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+    - uses: actions/cache/restore@v5
+      with:
+        path: ${{ runner.temp }}\cygwin-packages
+        key: cygwin-packages-0  # never matches, but syntactically required
+        restore-keys: cygwin-packages-
+
+    - name: Install Cygwin
+      id: cygwin-install
+      uses: ./
+      with:
+        package-cache: ${{ runner.temp }}\cygwin-packages
+
+    # It seems like the cache action doesn't provide a way to natively hash the
+    # directory it's caching (and hashFiles appears to be useless for that
+    # purpose, since it refuses to work outside of GITHUB_WORKSPACE), so roll
+    # our own.
+    #
+    # We just hash file name and size of all files in the package cache
+    # (ignoring the contents for performance, and timestamp because setup always
+    # touches setup.ini). If setup wrote some sort of package cache index, we'd
+    # just use the hash of that instead!
+    - name: Compute package cache hash
+      id: cygwin-package-cache-hash
+      run: |
+        cache_dir=$(cygpath -ua "${{ steps.cygwin-install.outputs.package-cache }}")
+        hash=$(find ${cache_dir} -type f -exec stat -c '%n %s' {} + | sha256sum | cut -d' ' -f1)
+        echo "hash=$hash" >> ${GITHUB_OUTPUT}
+      shell: bash -o igncr '{0}'
+
+    - uses: actions/cache/save@v5
+      # XXX: maybe don't do this if the key we're going to use is the same as
+      # cache-matched-key to avoid warning?
+      if: always()
+      with:
+        path: ${{ runner.temp }}\cygwin-packages
+        key: cygwin-packages-${{ steps.cygwin-package-cache-hash.outputs.hash }}
+
   pester:
     name: "Pester test suite"
     runs-on: "windows-latest"

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Table of Contents
   * [`check-hash`](#check-hash)
   * [`check-installer-sig`](#check-installer-sig)
   * [`check-sig`](#check-sig)
+  * [`package-cache`](#package-cache)
 
 * [Outputs](#outputs)
 
@@ -265,6 +266,20 @@ Example:
     check-sig: 'true'  # Change to 'false' only if required.
 ```
 
+### `package-cache`
+
+The absolute path to the package cache directory.
+
+The default package cache directory is `'D:\cygwin-packages'`,
+based on the [`work-vol`](#work-vol) input.
+
+Example:
+
+```yaml
+- uses: 'cygwin/cygwin-install-action@<version>'
+  with:
+    package-cache: ${{ runner.temp }}/cygwin-packages
+```
 
 Outputs
 -------

--- a/action.yml
+++ b/action.yml
@@ -45,6 +45,10 @@ inputs:
     description: Volume on which to store setup and packages, and install Cygwin
     required: false
     default: ''
+  package-cache:
+    description: Package cache directory
+    required: false
+    default: ''
 
 outputs:
   setup:
@@ -73,6 +77,7 @@ runs:
         inputs_check_hash: "${{ inputs.check-hash }}"
         inputs_check_installer_sig: "${{ inputs.check-installer-sig }}"
         inputs_work_vol: "${{ inputs.work-vol }}"
+        inputs_package_cache_dir: "${{ inputs.package-cache }}"
       run: |
         & $Env:GITHUB_ACTION_PATH\src\install.ps1
       shell: powershell

--- a/src/install.ps1
+++ b/src/install.ps1
@@ -47,6 +47,9 @@ if ("$env:inputs_install_dir" -ne '') {
 }
 
 $packageDir = "$vol\cygwin-packages"
+if ("$env:inputs_package_cache_dir" -ne '') {
+    $packageDir = "$env:inputs_package_cache_dir"
+}
 
 $packages = "$env:inputs_packages"
 $pkg_list = $packages.Split('', [System.StringSplitOptions]::RemoveEmptyEntries)


### PR DESCRIPTION
Add a package-cache dir input to the action, so usescan roll their own package caching.